### PR TITLE
Bump JVM toolchain from 8 to 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,5 +18,5 @@ tasks.test {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }


### PR DESCRIPTION
There's no reason to use Java 8 for this newly created project, as such, this PR bumps it to 17.